### PR TITLE
add proper self-require for CLJS macros

### DIFF
--- a/src/cljc/historian/core.cljc
+++ b/src/cljc/historian/core.cljc
@@ -1,7 +1,8 @@
 (ns ^{:doc "Manage states for your atoms. (Easy undo/redo)"
       :author "Frozenlock"
       :quote "The present is the least important time we live in. --Alan Kay"}
-    historian.core)
+    historian.core
+  #?(:cljs (:require-macros [historian.core :refer (off-the-record)])))
 
 (def alexandria 
   "The great library... store your stuff here."


### PR DESCRIPTION
This allows users to skip having to use `:require-macros` themselves and can just use macros directly.

Example:
```
  (:require [historian.core :refer (off-the-record)])
```